### PR TITLE
Make it work with 7.6, support _int

### DIFF
--- a/opaleye-gen.cabal
+++ b/opaleye-gen.cabal
@@ -19,7 +19,7 @@ executable opaleye-gen
                      , Generate
   default-language:    Haskell2010
   ghc-options:         -Wall
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.6 && < 5
                      , bytestring
                      , cases
                      , containers

--- a/src/Generate.hs
+++ b/src/Generate.hs
@@ -117,6 +117,7 @@ typeNameToHType col =
     "jsonb"       -> mval <> "JSON.Value"
     "varchar"     -> mval <> "Text"
     "_varchar"    -> "[Text]"
+    "_int4"       -> "[Int32]"
     "oid"         -> mval <> "Int64"
     "inet"        -> mval <> "Text"
     other         -> error $ "Unimplemented PostgresQL type conversion for " <> show other
@@ -147,6 +148,7 @@ pgTypeForColumn col =
     "jsonb"       -> nullify "PGJsonb"
     "varchar"     -> nullify "PGText"
     "_varchar"    -> nullify "(PGArray Text)"
+    "_int4"       -> nullify "(PGArray Int4)"
     "oid"         -> nullify "PGInt8"
     "inet"        -> nullify "PGText"
     other         -> error $ "Unimplemented PostgresQL type conversion for " <> show other

--- a/src/Generate.hs
+++ b/src/Generate.hs
@@ -4,7 +4,7 @@ module Generate where
 import           Prelude        hiding (unwords)
 
 import qualified Cases          as C
-import           Data.Monoid    ((<>))
+import           Data.Monoid    ((<>), mconcat)
 import           Data.Text      hiding (map)
 import           Database
 import           Text.Countable

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,6 +11,7 @@ import           Control.Monad
 import qualified Data.ByteString.Char8      as Char8
 import qualified Data.List                  as L
 import qualified Data.Map                   as M
+import           Data.Monoid                ((<>))
 import           Data.Ord                   (comparing)
 import           Data.Text                  hiding (map)
 import qualified Database.PostgreSQL.Simple as PGS


### PR DESCRIPTION
Opaleye works with GHC 7.6 so it would be nice if this tool did too.

I also added support for `_int`, though perhaps this should be done generically as per https://github.com/folsen/opaleye-gen/issues/1.